### PR TITLE
Remove SpeakerDeck link

### DIFF
--- a/full/regression-aml-designer/README.md
+++ b/full/regression-aml-designer/README.md
@@ -14,7 +14,7 @@ In this workshop, we will learn how to train **regression models** - machine Lea
 | **What you'll need**          | [Azure Subscription](https://azure-for-academics.github.io/getting-azure/) |
 | **Duration**                  | *1 hour*                                                                |
 | **Just want to try the app or see the solution?** |  |
-| **Slides** | [Powerpoint](RegressionAMLDesigner.pptx), [SpeakerDeck](https://speakerdeck.com/shwars/covid-paper-exploration-the-workshop) |
+| **Slides** | [Powerpoint](RegressionAMLDesigner.pptx) |
 | **Author** | [Dmitry Soshnikov](http://soshnikov.com) |
 
 


### PR DESCRIPTION
- SpeakerDeck link related to [covid-paper-text-analytics](https://github.com/microsoft/workshop-library/tree/main/full/covid-paper-text-analytics)
 workshop removed.